### PR TITLE
Sort configuration, parameters and hooks into consistent order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ce-util",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Utility for interacting with CE platform",
   "main": "index.js",
   "scripts": {

--- a/src/util/saveElementsToDir.js
+++ b/src/util/saveElementsToDir.js
@@ -16,13 +16,16 @@ module.exports = async (dir, data) => {
     }
     delete element.id
     element.configuration = map(dissoc('id'))(element.configuration)
+        .sort((a, b) => a.key.localeCompare(b.key))
     element.parameters = map(omit(['id', 'elementId', 'createdDate', 'updatedDate']))(element.parameters)
+        .sort((a, b) => a.name.localeCompare(b.name))
 
     element.hooks = map(pipe(
       omit(['id', 'elementId']),
       tap(h => writeFileSync(`${elementFolder}/${h.type}Hook.js`, h.body, 'utf8')),
       dissoc('body')
     ))(element.hooks)
+        .sort((a, b) => -(a.type.localeCompare(b.type)))
 
     if(element.resources) {
       const resourcesFolder = `${elementFolder}/resources`
@@ -32,6 +35,7 @@ module.exports = async (dir, data) => {
       element.resources = map(resource => {
         if(resource.parameters){
           resource.parameters = map(omit(['id', 'resourceId', 'createdDate', 'updatedDate']))(resource.parameters)
+              .sort((a, b) => a.name.localeCompare(b.name))
         }
         if(resource.hooks) {
           const uniqueName = getResourceName(resource)
@@ -40,6 +44,7 @@ module.exports = async (dir, data) => {
             tap(h => writeFileSync(`${resourcesFolder}/${uniqueName}${h.type}Hook.js`, h.body, 'utf8')),
             dissoc('body')
           ))(resource.hooks)
+              .sort((a, b) => -(a.type.localeCompare(b.type)))
         }
         return omit(['createdDate', 'updatedDate'], resource)
       })(element.resources)


### PR DESCRIPTION
This is to faciliate comparing when downloading elements in the directory format