### PR TITLE
Pagination support for importing formulas

### DIFF
--- a/src/util/getWithFullResponse.js
+++ b/src/util/getWithFullResponse.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const {curry, isNil, pathSatisfies, test} = require('ramda');
+const rp = require('request-promise');
+const authHeader = require('./authHeader');
+const baseUrl = require('./baseUrl');
+
+module.exports = curry(async (path,qs) => {
+  let options = {
+    json: true,
+    headers: {
+      Authorization: authHeader(),
+    },
+    url: baseUrl(path),
+    resolveWithFullResponse: true,
+    method: "GET",
+    strictSSL: false
+  };
+  qs?options.qs = qs:'';
+  
+  try {
+    return await rp(options);
+  } catch (err) {
+    if (pathSatisfies(res => !isNil(res), ['error', 'message'], err)
+      && test(/^No (.*) found$/, err.error.message)) {
+      return {}
+    } else {
+      throw err
+    }
+  }
+});


### PR DESCRIPTION
Fix to allow importing formulas when a Cloud Elements account has more than 200 formulas (default page limit).
The reason for this change is that the import will fail as the doctor will attempt to create formulas that already exist.

Pagination support was added when fetching formulas to determine if formula should be created or updated. 

Related tech support ticket - https://customerportal.uipath.com/support/details/5005b00001Sh9sZAAR