### PR TITLE
Pagination support for importing formulas - part 2

### DIFF
--- a/src/util/createFormulas.js
+++ b/src/util/createFormulas.js
@@ -3,7 +3,7 @@ const {map, find, propEq, mergeAll, curry, equals, assocPath} = require('ramda')
 const {emitter, EventTopic} = require('../events/emitter');
 const {isJobCancelled} = require('../events/cancelled-job');
 const {Assets, ArtifactStatus} = require('../constants/artifact');
-const get = require('./get');
+const get = require('./getWithFullResponse');
 const postFormula = require('./post')('formulas');
 const makePath = (formula) => `formulas/${formula.id}`;
 const update = require('./update');

--- a/src/util/getWithFullResponse.js
+++ b/src/util/getWithFullResponse.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const {curry, isNil, pathSatisfies, test} = require('ramda');
+const rp = require('request-promise');
+const authHeader = require('./authHeader');
+const baseUrl = require('./baseUrl');
+
+module.exports = curry(async (path,qs) => {
+  let options = {
+    json: true,
+    headers: {
+      Authorization: authHeader(),
+    },
+    url: baseUrl(path),
+    resolveWithFullResponse: true,
+    method: "GET",
+    strictSSL: false
+  };
+  qs?options.qs = qs:'';
+  
+  try {
+    return await rp(options);
+  } catch (err) {
+    if (pathSatisfies(res => !isNil(res), ['error', 'message'], err)
+      && test(/^No (.*) found$/, err.error.message)) {
+      return {}
+    } else {
+      throw err
+    }
+  }
+});


### PR DESCRIPTION
follow on from https://github.com/CloudElementsOpenLabs/the-doctor/pull/68

This was missed in the last PR but we need to return the response headers when using **request-promise**.
I created a new version of the `get.js` util called `getWithFullResponse.js` as to not make breaking changes in other areas where the `get.js` util is being used.